### PR TITLE
Structure

### DIFF
--- a/Sniffs/Arrays/MultiLineArrayCommaSniff.php
+++ b/Sniffs/Arrays/MultiLineArrayCommaSniff.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * This file is part of the Symfony2-coding-standard (phpcs standard)
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer-Symfony2
+ * @author   wicliff wolda <dev@bloody-wicked.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @version  GIT: master
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+
+/**
+ * Symfony2_Sniffs_WhiteSpace_MultiLineArrayCommaSniff.
+ *
+ * Throws warnings if the last item in a multi line array does not have a trailing comma
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer-Symfony2
+ * @author   wicliff wolda <dev@bloody-wicked.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+class Symfony2_Sniffs_Arrays_MultiLineArrayCommaSniff implements PHP_CodeSniffer_Sniff
+{
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = array(
+                                   'PHP',
+                                  );
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+                T_ARRAY,
+               );
+
+    }//end register()
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $open   = $tokens[$stackPtr];
+        $close  = $tokens[$open['parenthesis_closer']];
+
+        if ($open['line'] <> $close['line']) {
+            $lastComma = $phpcsFile->findPrevious(T_COMMA, $open['parenthesis_closer']);
+
+            while ($lastComma < $open['parenthesis_closer'] -1) {
+                $lastComma++;
+
+                if ($tokens[$lastComma]['code'] !== T_WHITESPACE) {
+                    $phpcsFile->addError(
+                        'Add a comma after each item in a multi-line array',
+                        $stackPtr,
+                        'Invalid'
+                    );
+                    break;
+                }
+            }
+        }
+
+    }//end process()
+
+}//end class
+

--- a/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of the Symfony2-coding-standard (phpcs standard)
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer-Symfony2
+ * @author   wicliff wolda <dev@bloody-wicked.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @version  GIT: master
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+
+/**
+ * Symfony2_Sniffs_Classes_PropertyDeclarationSniff.
+ *
+ * Throws warnings if properties are declared after methods
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer-Symfony2
+ * @author   wicliff wolda <dev@bloody-wicked.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+class Symfony2_Sniffs_Classes_PropertyDeclarationSniff implements PHP_CodeSniffer_Sniff
+{
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = array(
+        'PHP',
+    );
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            T_CLASS,
+        );
+    }//end register()
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $scope = $phpcsFile->findNext(T_FUNCTION, $stackPtr, $tokens[$stackPtr]['scope_closer']);
+
+        $wantedTokens = array(
+            T_PUBLIC,
+            T_PROTECTED,
+            T_PRIVATE
+        );
+
+        while ($scope) {
+            $scope = $phpcsFile->findNext($wantedTokens, $scope + 1, $tokens[$stackPtr]['scope_closer']);
+
+            if ($scope && $tokens[$scope + 2]['code'] === T_VARIABLE) {
+                $phpcsFile->addError(
+                    'Declare class properties before methods',
+                    $scope,
+                    'Invalid'
+                );
+            }
+        }
+    }//end process()
+
+}//end class

--- a/Sniffs/Functions/ScopeOrderSniff.php
+++ b/Sniffs/Functions/ScopeOrderSniff.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * This file is part of the Symfony2-coding-standard (phpcs standard)
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer-Symfony2
+ * @author   wicliff wolda <dev@bloody-wicked.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @version  GIT: master
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+
+/**
+ * Symfony2_Sniffs_Functions_ScopeOrderSniff.
+ *
+ * Throws warnings if properties are declared after methods
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer-Symfony2
+ * @author   wicliff wolda <dev@bloody-wicked.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+class Symfony2_Sniffs_Functions_ScopeOrderSniff implements PHP_CodeSniffer_Sniff
+{
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = array(
+        'PHP',
+    );
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            T_CLASS,
+            T_INTERFACE,
+        );
+    }//end register()
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $function = $stackPtr;
+
+        $scopes = array(
+            0 => T_PUBLIC,
+            1 => T_PROTECTED,
+            2 => T_PRIVATE,
+        );
+
+        $whitelisted = array(
+            '__construct',
+            'setUp',
+            'tearDown',
+        );
+
+        while ($function) {
+            $function = $phpcsFile->findNext(T_FUNCTION, $function + 1, $tokens[$stackPtr]['scope_closer']);
+
+            if (isset($tokens[$function]['parenthesis_opener'])) {
+                $scope = $phpcsFile->findPrevious($scopes, $function -1, $stackPtr);
+                $name = $phpcsFile->findNext(T_STRING, $function + 1, $tokens[$function]['parenthesis_opener']);
+
+                if ($scope && $name && !in_array($tokens[$name]['content'], $whitelisted)) {
+                    $current = array_keys($scopes,  $tokens[$scope]['code']);
+                    $current = $current[0];
+
+                    if (isset($previous) && $current < $previous) {
+                        $phpcsFile->addError(
+                            'Declare public methods first, then protected ones and finally private ones',
+                            $scope,
+                            'Invalid'
+                        );
+                    }
+
+                    $previous = $current;
+                }
+            }
+        }
+    }//end process()
+
+}//end class

--- a/Sniffs/Objects/ObjectInstantiationSniff.php
+++ b/Sniffs/Objects/ObjectInstantiationSniff.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of the Symfony2-coding-standard (phpcs standard)
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer-Symfony2
+ * @author   wicliff wolda <dev@bloody-wicked.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @version  GIT: master
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+
+/**
+ * Symfony2_Sniffs_Objects_ObjectInstantiationSniff.
+ *
+ * Throws a warning if an object isn't instantiated using parenthesis.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer-Symfony2
+ * @author   wicliff wolda <dev@bloody-wicked.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+class Symfony2_Sniffs_Objects_ObjectInstantiationSniff implements PHP_CodeSniffer_Sniff
+{
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = array(
+                                   'PHP',
+                                  );
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+                T_NEW,
+               );
+
+    }//end register()
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $object = $phpcsFile->findNext(T_STRING, $stackPtr + 1);
+
+        if ($object && $tokens[$object + 1]['code'] !== T_OPEN_PARENTHESIS) {
+            $phpcsFile->addError(
+                'Use parentheses when instantiating classes',
+                $stackPtr,
+                'Invalid'
+            );
+        }
+
+    }//end process()
+
+}//end class
+

--- a/Sniffs/WhiteSpace/BinaryOperatorSpacingSniff.php
+++ b/Sniffs/WhiteSpace/BinaryOperatorSpacingSniff.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of the Symfony2-coding-standard (phpcs standard)
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer-Symfony2
+ * @author   wicliff wolda <dev@bloody-wicked.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @version  GIT: master
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+
+/**
+ * Symfony2_Sniffs_WhiteSpace_BinaryOperatorSpacingSniff.
+ *
+ * Throws warnings if a binary operator isn't surrounded with whitespace.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer-Symfony2
+ * @author   wicliff wolda <dev@bloody-wicked.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+class Symfony2_Sniffs_WhiteSpace_BinaryOperatorSpacingSniff
+{
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = array(
+                                   'PHP',
+                                  );
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return PHP_CodeSniffer_Tokens::$comparisonTokens;
+
+    }//end register()
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr -1]['code'] !== T_WHITESPACE || $tokens[$stackPtr +1]['code'] !== T_WHITESPACE) {
+            $phpcsFile->addError(
+                'Add a single space around binary operators',
+                $stackPtr,
+                'Invalid'
+            );
+        }
+    }//end process()
+
+}//end class

--- a/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of the Symfony2-coding-standard (phpcs standard)
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer-Symfony2
+ * @author   wicliff wolda <dev@bloody-wicked.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @version  GIT: master
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+
+/**
+ * Symfony2_Sniffs_WhiteSpace_CommaSpacingSniff.
+ *
+ * Throws warnings if comma isn't followed by a whitespace.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer-Symfony2
+ * @author   wicliff wolda <dev@bloody-wicked.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+class Symfony2_Sniffs_WhiteSpace_CommaSpacingSniff implements PHP_CodeSniffer_Sniff
+{
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = array(
+                                   'PHP',
+                                  );
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+                T_COMMA,
+               );
+
+    }//end register()
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $line   = $tokens[$stackPtr]['line'];
+
+        while ($tokens[$stackPtr]['line'] == $line) {
+
+            // making sure the comma isn't at the end of a line
+            if ($tokens[($stackPtr + 1)]['line'] === $line && $tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
+                $phpcsFile->addError(
+                    'Add a single space after each comma delimiter',
+                    $stackPtr,
+                    'Invalid'
+                );
+                break;
+            }
+
+            $stackPtr++;
+        }
+
+    }//end process()
+
+}//end class
+

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -13,12 +13,9 @@
 
     # Structure
 
-    * Declare class properties before methods;
-    * Declare public methods first, then protected ones and finally private ones.
-    * Use namespaces for all classes;
-    * Add PHPDoc blocks for all classes, methods, and functions;
     * The @package and @subpackage annotations are not used.
     * Use uppercase strings for constants with words separated with underscores
+    * Exception message strings should be concatenated using sprintf
 
     # Naming Conventions
 
@@ -38,6 +35,7 @@
     <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
     <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
     <rule ref="Squiz.Scope.MemberVarScope"/>
+    <rule ref="Squiz.Strings.ConcatenationSpacing"/>
 
     <!-- We provide our own subclass of PEAR's ClassComment and FunctionComment sniff, but these will do: -->
     <rule ref="PEAR.Commenting.InlineComment"/>


### PR DESCRIPTION
covers most standards listed under [Structure](http://symfony.com/doc/current/contributing/code/standards.html#structure) except for the ``Exception message strings should be concatenated using sprintf.`` one