### PR TITLE
bugfixes

### DIFF
--- a/Sniffs/NamingConventions/ValidClassNameSniff.php
+++ b/Sniffs/NamingConventions/ValidClassNameSniff.php
@@ -124,8 +124,10 @@ class Symfony2_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeS
              */
             if ('T_ABSTRACT' == $tokens[$stackPtr]['type']) {
                 $name = $phpcsFile->findNext(T_STRING, $stackPtr);
-
-                if ($name && substr($tokens[$name]['content'], 0, 8) != 'Abstract') {
+                $function = $phpcsFile->findNext(T_FUNCTION, $stackPtr);
+                
+                // making sure we're not dealing with an abstract function
+                if ($name && (is_null($function) || $name < $function) && substr($tokens[$name]['content'], 0, 8) != 'Abstract') {
                     $phpcsFile->addError(
                         'Abstract class name is not prefixed with "Abstract"',
                         $stackPtr,

--- a/Sniffs/Objects/ObjectInstantiationSniff.php
+++ b/Sniffs/Objects/ObjectInstantiationSniff.php
@@ -61,14 +61,28 @@ class Symfony2_Sniffs_Objects_ObjectInstantiationSniff implements PHP_CodeSniffe
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        $object = $phpcsFile->findNext(T_STRING, $stackPtr + 1);
+        $allowed = array(
+            T_STRING,
+            T_NS_SEPARATOR,
+        );
 
-        if ($object && $tokens[$object + 1]['code'] !== T_OPEN_PARENTHESIS) {
-            $phpcsFile->addError(
-                'Use parentheses when instantiating classes',
-                $stackPtr,
-                'Invalid'
-            );
+        $object = $stackPtr;
+        $line   = $tokens[$object]['line'];
+
+        while ($object && $tokens[$object]['line'] === $line) {
+            $object = $phpcsFile->findNext($allowed, $object + 1);
+
+            if ($tokens[$object]['line'] === $line && !in_array($tokens[$object + 1]['code'], $allowed)) {
+                if ($tokens[$object + 1]['code'] !== T_OPEN_PARENTHESIS) {
+                    $phpcsFile->addError(
+                        'Use parentheses when instantiating classes',
+                        $stackPtr,
+                        'Invalid'
+                    );
+                }
+
+                break;
+            }
         }
 
     }//end process()


### PR DESCRIPTION
hi @djoos,
thanks for merging the other two pull requests! 
here's a small addition which fixes the following bugs:

``Abstract class name is not prefixed with "Abstract"`` error raised while running into
```php
abstract public function getType();
```
``Use parentheses when instantiating classes`` error raised while running into
```php
$foo = new My\Qualified\Namespace\Bar();
```