### PR TITLE
Composerified

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Codesniffer ruleset for the Symfony2 coding standard",
     "target-dir": "escapestudios/phpcs/Symfnoy2",
     "require": {
-        "squizlabs/php_codesniffer": "~2.0",
+        "squizlabs/php_codesniffer": "~2.0"
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "escapestudios/symfony2-coding-standard",
     "description": "Codesniffer ruleset for the Symfony2 coding standard",
-    "target-dir": "escapestudios/phpcs/Symfnoy2",
+    "target-dir": "escapestudios/phpcs/Symfony2",
     "require": {
         "squizlabs/php_codesniffer": "~2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "escapestudios/symfony2-coding-standard",
+    "description": "Codesniffer ruleset for the Symfony2 coding standard",
+    "target-dir": "escapestudios/phpcs/Symfnoy2",
+    "require": {
+        "squizlabs/php_codesniffer": "~2.0",
+    },
+    "minimum-stability": "dev"
+}


### PR DESCRIPTION
Allow Symfony2 standard to be installed via composer. To install this standard, do the following:
1. Add a repository to your projects composer.json.
```
    "repositories": [
         {"type": "vcs","url":  "git@github.com:escapestudios/Symfony2-coding-standard.git"}
    ],
```

2. Install the standard.  
` composer require escapestudios/symfony2-coding-standard`

3. Add the standard to phpcs' installed_paths'.  
`bin/phpcs --config-set installed_paths ../../escapestudios/symfony2-coding-standard/escapestudios/phpcs/`

4. Have fun...  
`bin/phpcs --standard=Symfony2 ./`

_To be able to skip the first step, escapestudios should add this project to packagist.org._