### PR TITLE
Remove deprecated target-dir directive from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,5 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.0"
-    },
-    "target-dir": "escapestudios/Symfony2-coding-standard"
+    }
 }


### PR DESCRIPTION
This isn't needed any more now that  we're nesting the standard under
the Symfony2 directory. The target-dir directive is used to nest the
project under the composer chosen location. By default, this will be
'escapestudios/symfony2-coding-standard', so having this directive with
that same path will result in the code path being
'escapestudios/symfony2-coding-standard/escapestudios/symfony2-coding-standard'.

This directive was only really useful before we nested the standard
under the Symfony2 directory, as it allowed us to add "Symfony2" to the
destination path, allowing PHP_CodeSniffer to find the standard automatically
based on the folder name when setting the "installed_paths" config.