### PR TITLE
Make MultiLineArrayCommaSniff work for the short-array syntax '[]'

### DIFF
--- a/Symfony2/Sniffs/Arrays/MultiLineArrayCommaSniff.php
+++ b/Symfony2/Sniffs/Arrays/MultiLineArrayCommaSniff.php
@@ -15,7 +15,8 @@
 /**
  * Symfony2_Sniffs_WhiteSpace_MultiLineArrayCommaSniff.
  *
- * Throws warnings if the last item in a multi line array does not have a trailing comma
+ * Throws warnings if the last item in a multi line array does not have a
+ * trailing comma
  *
  * @category PHP
  * @package  PHP_CodeSniffer-Symfony2
@@ -23,7 +24,8 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Sniffs_Arrays_MultiLineArrayCommaSniff implements PHP_CodeSniffer_Sniff
+class Symfony2_Sniffs_Arrays_MultiLineArrayCommaSniff
+    implements PHP_CodeSniffer_Sniff
 {
     /**
      * A list of tokenizers this sniff supports.
@@ -43,6 +45,7 @@ class Symfony2_Sniffs_Arrays_MultiLineArrayCommaSniff implements PHP_CodeSniffer
     {
         return array(
                 T_ARRAY,
+                T_OPEN_SHORT_ARRAY,
                );
 
     }//end register()
@@ -60,12 +63,17 @@ class Symfony2_Sniffs_Arrays_MultiLineArrayCommaSniff implements PHP_CodeSniffer
     {
         $tokens = $phpcsFile->getTokens();
         $open   = $tokens[$stackPtr];
-        $close  = $tokens[$open['parenthesis_closer']];
 
-        if ($open['line'] <> $close['line']) {
-            $lastComma = $phpcsFile->findPrevious(T_COMMA, $open['parenthesis_closer']);
+        if ($open['code'] === T_ARRAY) {
+            $closePtr = $open['parenthesis_closer'];
+        } else {
+            $closePtr = $open['bracket_closer'];
+        }
 
-            while ($lastComma < $open['parenthesis_closer'] -1) {
+        if ($open['line'] <> $tokens[$closePtr]['line']) {
+            $lastComma = $phpcsFile->findPrevious(T_COMMA, $closePtr);
+
+            while ($lastComma < $closePtr -1) {
                 $lastComma++;
 
                 if ($tokens[$lastComma]['code'] !== T_WHITESPACE) {

--- a/Symfony2/Tests/Arrays/MultiLineArrayCommaUnitTest.inc
+++ b/Symfony2/Tests/Arrays/MultiLineArrayCommaUnitTest.inc
@@ -1,0 +1,26 @@
+<?php
+
+// Classic array syntax
+$arr = array('foo', 'bar');
+$arr = array(
+        'foo'
+        'bar',
+);
+
+$arr = array(
+        'foo'
+        'bar'
+);
+
+// Short array syntax
+$arr = ['foo', 'bar'];
+$arr = [
+        'foo'
+        'bar',
+];
+
+$arr = [
+        'foo'
+        'bar'
+];
+

--- a/Symfony2/Tests/Arrays/MultiLineArrayCommaUnitTest.php
+++ b/Symfony2/Tests/Arrays/MultiLineArrayCommaUnitTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This file is part of the Symfony2-coding-standard (phpcs standard)
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer-Symfony2
+ * @author   Symfony2-phpcs-authors <Symfony2-coding-standard@escapestudios.github.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @version  GIT: master
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+/**
+ * Unit test class for the MultiLineArrayComma sniff.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   Craige leeder <craige@craigeleeder.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+class Symfony2_Tests_Arrays_MultiLineArrayCommaUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return array(
+                10  => 1,
+                22 => 1,
+                );
+    }//end getErrorList()
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return array();
+    }//end getErrorList()
+}//end class
+?>


### PR DESCRIPTION
Fixes #17.