### PR TITLE
Deactivate SpaceAfterCloseBracket PEAR Rule

### DIFF
--- a/Symfony2/ruleset.xml
+++ b/Symfony2/ruleset.xml
@@ -74,6 +74,9 @@
     <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
         <severity>0</severity>
     </rule>
+    <rule ref="PEAR.Functions.FunctionCallSignature.SpaceAfterCloseBracket">
+        <severity>0</severity>
+    </rule>
     <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
         <severity>0</severity>
     </rule>


### PR DESCRIPTION
This rules cause problem with some Symfony bundle generated code like sonata-admin.

Here an example.
```php
protected function configureListFields(ListMapper $listMapper)
{
    $listMapper
        ->add('ref')
        ->add('isValid')
        ->add('_action', 'actions', array(
            'actions' => array(
                'show'      => array(),
                'edit'      => array(),
            )
        ))
    ;
}
```

This will throw the following error 'Space after closing parenthesis of function call prohibited'.

But this is not prohibited on Symfony2 coding standards.

Already made and accepted on an another similar project: https://github.com/leaphub/phpcs-symfony2-standard/pull/1