### PR TITLE
fixed failing ObjectInstantiationSniff on variable class names

### DIFF
--- a/Symfony2/Sniffs/Objects/ObjectInstantiationSniff.php
+++ b/Symfony2/Sniffs/Objects/ObjectInstantiationSniff.php
@@ -64,6 +64,7 @@ class Symfony2_Sniffs_Objects_ObjectInstantiationSniff implements PHP_CodeSniffe
         $allowed = array(
             T_STRING,
             T_NS_SEPARATOR,
+            T_VARIABLE,
         );
 
         $object = $stackPtr;
@@ -88,4 +89,3 @@ class Symfony2_Sniffs_Objects_ObjectInstantiationSniff implements PHP_CodeSniffe
     }//end process()
 
 }//end class
-

--- a/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.inc
+++ b/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.inc
@@ -1,0 +1,23 @@
+<?php
+
+//bad
+new Foo;
+new Foo\Bar;
+new \Foo\Bar;
+new $foo;
+new Foo ();
+
+//good
+new Foo();
+new foo();
+new Foo(true);
+new Foo($this->foo);
+new Foo\Bar();
+new Foo\Bar(true);
+new Foo\Bar($this->foo);
+new \Foo\Bar();
+new \Foo\Bar(true);
+new \Foo\Bar($this->foo);
+new $foo();
+new $foo(true);
+new $foo($this->foo);

--- a/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.php
+++ b/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This file is part of the Symfony2-coding-standard (phpcs standard)
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer-Symfony2
+ * @author   Symfony2-phpcs-authors <Symfony2-coding-standard@escapestudios.github.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @version  GIT: master
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+
+/**
+ * Unit test class for the ObjectInstantiation sniff.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   Roman Weich <roman.weich@gmail.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+
+class Symfony2_Tests_Objects_ObjectInstantiationUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return array(
+            4  => 1,
+            5  => 1,
+            6  => 1,
+            7  => 1,
+            8  => 1,
+        );
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    public function getWarningList()
+    {
+        return array();
+    }
+}


### PR DESCRIPTION
the sniff reported an error on
```php
$foo = "\\a\\b\\c";
$bar = new $foo("baz");
```

it did not report an error on
```php
$foo = new $bar;
```

the pr is fixing both