### PR TITLE
Made the error codes for invalid class names more specific.

### DIFF
--- a/Symfony2/Sniffs/NamingConventions/ValidClassNameSniff.php
+++ b/Symfony2/Sniffs/NamingConventions/ValidClassNameSniff.php
@@ -76,7 +76,7 @@ class Symfony2_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeS
                     $phpcsFile->addError(
                         'Interface name is not suffixed with "Interface"',
                         $stackPtr,
-                        'InvalidInterface'
+                        'InvalidInterfaceName'
                     );
                 }
                 break;
@@ -92,7 +92,7 @@ class Symfony2_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeS
                     $phpcsFile->addError(
                         'Trait name is not suffixed with "Trait"',
                         $stackPtr,
-                        'InvalidTrait'
+                        'InvalidTraitName'
                     );
                 }
                 break;
@@ -112,7 +112,7 @@ class Symfony2_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeS
                         $phpcsFile->addError(
                             'Exception name is not suffixed with "Exception"',
                             $stackPtr,
-                            'InvalidExtends'
+                            'InvalidExceptionName'
                         );
                     }
                 }
@@ -131,7 +131,7 @@ class Symfony2_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeS
                     $phpcsFile->addError(
                         'Abstract class name is not prefixed with "Abstract"',
                         $stackPtr,
-                        'InvalidAbstract'
+                        'InvalidAbstractName'
                     );
                 }
                 break;

--- a/Symfony2/Sniffs/NamingConventions/ValidClassNameSniff.php
+++ b/Symfony2/Sniffs/NamingConventions/ValidClassNameSniff.php
@@ -76,7 +76,7 @@ class Symfony2_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeS
                     $phpcsFile->addError(
                         'Interface name is not suffixed with "Interface"',
                         $stackPtr,
-                        'Invalid'
+                        'InvalidInterface'
                     );
                 }
                 break;
@@ -92,7 +92,7 @@ class Symfony2_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeS
                     $phpcsFile->addError(
                         'Trait name is not suffixed with "Trait"',
                         $stackPtr,
-                        'Invalid'
+                        'InvalidTrait'
                     );
                 }
                 break;
@@ -112,7 +112,7 @@ class Symfony2_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeS
                         $phpcsFile->addError(
                             'Exception name is not suffixed with "Exception"',
                             $stackPtr,
-                            'Invalid'
+                            'InvalidExtends'
                         );
                     }
                 }
@@ -131,7 +131,7 @@ class Symfony2_Sniffs_NamingConventions_ValidClassNameSniff implements PHP_CodeS
                     $phpcsFile->addError(
                         'Abstract class name is not prefixed with "Abstract"',
                         $stackPtr,
-                        'Invalid'
+                        'InvalidAbstract'
                     );
                 }
                 break;


### PR DESCRIPTION
This makes it possible to ignore certain invalid class names, but keep on checking for others.
For example:

    <rule ref="Symfony2.NamingConventions.ValidClassName.InvalidAbstractName">
        <exclude-pattern>*</exclude-pattern>
    </rule>

This will ignore all errors saying that abstract class names should be prefixed with "Abstract", but keeps on checking that interfaces are suffixed with Interface, etc.

I know that abstract classes should always be prefixed with Abstract in Symfony2, but this just makes it easier for those of us who want to create their own ruleset for other projects.

We use a lot of the Symfony2 rules in our Silex projects for example, but don't always want to prefix all of our abstract classes with Abstract.