### PR TITLE
Fix PHP notices

### DIFF
--- a/Symfony2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/Symfony2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -60,7 +60,11 @@ class Symfony2_Sniffs_Classes_PropertyDeclarationSniff implements PHP_CodeSniffe
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        $scope = $phpcsFile->findNext(T_FUNCTION, $stackPtr, $tokens[$stackPtr]['scope_closer']);
+        $scope = $phpcsFile->findNext(
+            T_FUNCTION,
+            $stackPtr,
+            isset($tokens[$stackPtr]['scope_closer']) ? $tokens[$stackPtr]['scope_closer'] : null
+        );
 
         $wantedTokens = array(
             T_PUBLIC,

--- a/Symfony2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/Symfony2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -73,7 +73,11 @@ class Symfony2_Sniffs_Classes_PropertyDeclarationSniff implements PHP_CodeSniffe
         );
 
         while ($scope) {
-            $scope = $phpcsFile->findNext($wantedTokens, $scope + 1, $tokens[$stackPtr]['scope_closer']);
+            $scope = $phpcsFile->findNext(
+                $wantedTokens,
+                $scope + 1,
+                isset($tokens[$stackPtr]['scope_closer']) ? $tokens[$stackPtr]['scope_closer'] : null
+            );
 
             if ($scope && $tokens[$scope + 2]['code'] === T_VARIABLE) {
                 $phpcsFile->addError(

--- a/Symfony2/Sniffs/Functions/ScopeOrderSniff.php
+++ b/Symfony2/Sniffs/Functions/ScopeOrderSniff.php
@@ -76,7 +76,11 @@ class Symfony2_Sniffs_Functions_ScopeOrderSniff implements PHP_CodeSniffer_Sniff
         );
 
         while ($function) {
-            $function = $phpcsFile->findNext(T_FUNCTION, $function + 1, $tokens[$stackPtr]['scope_closer']);
+            $function = $phpcsFile->findNext(
+                T_FUNCTION,
+                $function + 1,
+                isset($tokens[$stackPtr]['scope_closer']) ? $tokens[$stackPtr]['scope_closer'] : null
+            );
 
             if (isset($tokens[$function]['parenthesis_opener'])) {
                 $scope = $phpcsFile->findPrevious($scopes, $function -1, $stackPtr);


### PR DESCRIPTION
* PHP Notice: Undefined index: scope_closer in /usr/share/pear/PHP/CodeSniffer/Standards/Symfony2/Sniffs/Classes/PropertyDeclarationSniff.php on line 63
* PHP Notice: Undefined index: scope_closer in /usr/share/pear/PHP/CodeSniffer/Standards/Symfony2/Sniffs/Functions/ScopeOrderSniff.php on line 79