### PR TITLE
Travis fix and improve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,6 @@ php:
   - 5.6
   - 7.0
   - hhvm
-  - hhvm-nightly
-
-matrix:
-  allow_failures:
-    - php: 7
-    - php: hhvm
-    - php: hhvm-nightly
 
 before_script:
     - export PHPCS_GITHUB_SRC=squizlabs/PHP_CodeSniffer


### PR DESCRIPTION
* Remove HHVM and PHP7 from allowed failure (it works!)
* Remove unsupported HHVM nightly: https://travis-ci.org/escapestudios/Symfony2-coding-standard/jobs/93497660#L70