### PR TITLE
Object instantiation by static

### DIFF
--- a/Symfony2/Sniffs/Objects/ObjectInstantiationSniff.php
+++ b/Symfony2/Sniffs/Objects/ObjectInstantiationSniff.php
@@ -65,6 +65,7 @@ class Symfony2_Sniffs_Objects_ObjectInstantiationSniff implements PHP_CodeSniffe
             T_STRING,
             T_NS_SEPARATOR,
             T_VARIABLE,
+            T_STATIC,
         );
 
         $object = $stackPtr;

--- a/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.inc
+++ b/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.inc
@@ -21,3 +21,6 @@ new \Foo\Bar($this->foo);
 new $foo();
 new $foo(true);
 new $foo($this->foo);
+new static();
+new static(true);
+new static($this->foo);

--- a/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.inc
+++ b/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.inc
@@ -6,6 +6,8 @@ new Foo\Bar;
 new \Foo\Bar;
 new $foo;
 new Foo ();
+new static;
+new self;
 
 //good
 new Foo();

--- a/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.php
+++ b/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.php
@@ -43,8 +43,8 @@ class Symfony2_Tests_Objects_ObjectInstantiationUnitTest extends AbstractSniffUn
             6  => 1,
             7  => 1,
             8  => 1,
-        	9  => 1,
-        	10 => 1,
+            9  => 1,
+            10 => 1,
         );
     }
 

--- a/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.php
+++ b/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.php
@@ -43,6 +43,8 @@ class Symfony2_Tests_Objects_ObjectInstantiationUnitTest extends AbstractSniffUn
             6  => 1,
             7  => 1,
             8  => 1,
+        	9  => 1,
+        	10 => 1,
         );
     }
 


### PR DESCRIPTION
Instantiating objects using static (e.g. `$obj = new static();`) can be useful when we want to create object of called class. Symfony2 standard does not forbid this, but symfony2 standard checker shows
"Use parentheses when instantiating classes" error even if parentheses are used.
Also code like `$obj = static;` is not causing any error.
This pull request fix this.